### PR TITLE
Draft: Database Redesign Group Chat

### DIFF
--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -3,6 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Box } from "@material-ui/core";
 import { Input, Header, Messages } from "./index";
 import { connect } from "react-redux";
+import { getLastSeenMessage } from '../../store/helpers'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -22,9 +23,11 @@ const useStyles = makeStyles(() => ({
 
 const ActiveChat = (props) => {
   const classes = useStyles();
-  const { user } = props;
+  const { user, activeConversation } = props;
   const conversation = props.conversation || {};
 
+  const lastMessage = getLastSeenMessage(user, conversation);
+  
   return (
     <Box className={classes.root}>
       {conversation.otherUser && (
@@ -37,12 +40,15 @@ const ActiveChat = (props) => {
             <Messages
               messages={conversation.messages}
               otherUser={conversation.otherUser}
-              user={user}
+              userId={user.id}
+              lastMessage={lastMessage[0]}
+              activeConversation={activeConversation}
             />
             <Input
               otherUser={conversation.otherUser}
               conversationId={conversation.id}
               user={user}
+              activeConversation={activeConversation}
             />
           </Box>
         </>
@@ -54,6 +60,7 @@ const ActiveChat = (props) => {
 const mapStateToProps = (state) => {
   return {
     user: state.user,
+    activeConversation: state.activeConversation,
     conversation:
       state.conversations &&
       state.conversations.find(

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles(() => ({
 const Input = (props) => {
   const classes = useStyles();
   const [text, setText] = useState("");
-  const { postMessage, otherUser, conversationId, user, activeConversation } = props;
+  const { postMessage, otherUser, conversationId, user } = props;
 
   const handleChange = (event) => {
     setText(event.target.value);

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles(() => ({
 const Input = (props) => {
   const classes = useStyles();
   const [text, setText] = useState("");
-  const { postMessage, otherUser, conversationId, user } = props;
+  const { postMessage, otherUser, conversationId, user, activeConversation } = props;
 
   const handleChange = (event) => {
     setText(event.target.value);

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -4,7 +4,7 @@ import { SenderBubble, OtherUserBubble } from "../ActiveChat";
 import moment from "moment";
 
 const Messages = (props) => {
-  const { messages, otherUser, userId, lastMessage, activeConversation } = props;
+  const { messages, otherUser, userId, lastMessage } = props;
 
   return (
     <Box>
@@ -12,7 +12,7 @@ const Messages = (props) => {
         const time = moment(message.createdAt).format("h:mm");
 
         return message.senderId === userId ? (
-          <SenderBubble key={message.id} text={message.text} time={time} otherUser={otherUser} lastMessage={lastMessage} message={message} userId={userId} activeConversation={activeConversation} />
+          <SenderBubble key={message.id} text={message.text} time={time} otherUser={otherUser} lastMessage={lastMessage} messageId={message.id} />
         ) : (
           <OtherUserBubble key={message.id} text={message.text} time={time} otherUser={otherUser} />
         );

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -4,15 +4,15 @@ import { SenderBubble, OtherUserBubble } from "../ActiveChat";
 import moment from "moment";
 
 const Messages = (props) => {
-  const { messages, otherUser, user, lastMessage } = props;
+  const { messages, otherUser, userId, lastMessage, activeConversation } = props;
 
   return (
     <Box>
       {messages.map((message) => {
         const time = moment(message.createdAt).format("h:mm");
 
-        return message.senderId === user.id ? (
-          <SenderBubble key={message.id} text={message.text} time={time} otherUser={otherUser} lastMessage={lastMessage} message={message}/>
+        return message.senderId === userId ? (
+          <SenderBubble key={message.id} text={message.text} time={time} otherUser={otherUser} lastMessage={lastMessage} message={message} userId={userId} activeConversation={activeConversation} />
         ) : (
           <OtherUserBubble key={message.id} text={message.text} time={time} otherUser={otherUser} />
         );

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -4,7 +4,7 @@ import { SenderBubble, OtherUserBubble } from "../ActiveChat";
 import moment from "moment";
 
 const Messages = (props) => {
-  const { messages, otherUser, user } = props;
+  const { messages, otherUser, user, lastMessage } = props;
 
   return (
     <Box>
@@ -12,7 +12,7 @@ const Messages = (props) => {
         const time = moment(message.createdAt).format("h:mm");
 
         return message.senderId === user.id ? (
-          <SenderBubble key={message.id} text={message.text} time={time} user={user} />
+          <SenderBubble key={message.id} text={message.text} time={time} otherUser={otherUser} lastMessage={lastMessage} message={message}/>
         ) : (
           <OtherUserBubble key={message.id} text={message.text} time={time} otherUser={otherUser} />
         );

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -35,15 +35,14 @@ const useStyles = makeStyles(() => ({
 
 const SenderBubble = (props) => {
   const classes = useStyles();
-  const { time, text, otherUser, lastMessage, message,activeConversation } = props;
+  const { time, text, otherUser, lastMessage, messageId } = props;
   return (
     <Box className={classes.root}> 
       <Typography className={classes.date}>{time}</Typography>
       <Box className={classes.bubble}>
         <Typography className={classes.text}>{text}</Typography>
       </Box>
-      { lastMessage && lastMessage.id === message.id && 
-      // activeConversation === otherUser.username && 
+      { lastMessage && lastMessage.id === messageId && 
       <Avatar alt={otherUser.username} src={otherUser.photoUrl} className={classes.avatar}></Avatar>
       }
     </Box>

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Box, Typography, Avatar } from "@material-ui/core";
-import Messages from './Messages';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -36,14 +35,15 @@ const useStyles = makeStyles(() => ({
 
 const SenderBubble = (props) => {
   const classes = useStyles();
-  const { time, text, otherUser, lastMessage, message } = props;
+  const { time, text, otherUser, lastMessage, message,activeConversation } = props;
   return (
-    <Box className={classes.root}>
+    <Box className={classes.root}> 
       <Typography className={classes.date}>{time}</Typography>
       <Box className={classes.bubble}>
         <Typography className={classes.text}>{text}</Typography>
       </Box>
-      { lastMessage.id === message.id && 
+      { lastMessage && lastMessage.id === message.id && 
+      // activeConversation === otherUser.username && 
       <Avatar alt={otherUser.username} src={otherUser.photoUrl} className={classes.avatar}></Avatar>
       }
     </Box>

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Box, Typography, Avatar } from "@material-ui/core";
+import Messages from './Messages';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -8,50 +9,43 @@ const useStyles = makeStyles(() => ({
     flexDirection: "column",
     alignItems: "flex-end"
   },
-  row: {
-    display: "flex",
-    flexDirection: "row",
-  },
-  avatar: {
-    height: 30,
-    width: 30,
-    marginLeft: 11,
-    marginTop: 6
-  },
   date: {
     fontSize: 11,
     color: "#BECCE2",
     fontWeight: "bold",
     marginBottom: 5
   },
-  bubble: {
-    marginRight: 20,
-    backgroundImage: "linear-gradient(225deg, #6CC1FF 0%, #3A8DFF 100%)",
-    borderRadius: "10px 0px 10px 10px"
-  },
   text: {
     fontSize: 14,
-    fontWeight: "bold",
-    color: "#FFFFFF",
+    color: "#91A3C0",
     letterSpacing: -0.2,
-    padding: 8
-  }
+    padding: 8,
+    fontWeight: "bold"
+  },
+  bubble: {
+    background: "#F4F6FA",
+    borderRadius: "10px 10px 0 10px"
+  },
+  avatar: {
+    height: 20,
+    width: 20,
+    marginRight: 11,
+    marginTop: 6
+  },
 }));
 
 const SenderBubble = (props) => {
   const classes = useStyles();
-  const { text, time, user } = props;
+  const { time, text, otherUser, lastMessage, message } = props;
   return (
     <Box className={classes.root}>
-      <Box className={classes.row}>
-        <Typography className={classes.date}>
-          {user.username} {time}
-        </Typography>
-        <Avatar alt={user.username} src={user.photoUrl} className={classes.avatar}></Avatar>
+      <Typography className={classes.date}>{time}</Typography>
+      <Box className={classes.bubble}>
+        <Typography className={classes.text}>{text}</Typography>
       </Box>
-        <Box className={classes.bubble}>
-          <Typography className={classes.text}>{text}</Typography>
-        </Box>
+      { lastMessage.id === message.id && 
+      <Avatar alt={otherUser.username} src={otherUser.photoUrl} className={classes.avatar}></Avatar>
+      }
     </Box>
   );
 };

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -3,6 +3,7 @@ import { Box } from "@material-ui/core";
 import { BadgeAvatar, ChatContent } from "../Sidebar";
 import { makeStyles } from "@material-ui/core/styles";
 import { setActiveChat } from "../../store/activeConversation";
+import { resetUnread } from "../../store/utils/thunkCreators";
 import { connect } from "react-redux";
 
 const useStyles = makeStyles((theme) => ({
@@ -26,6 +27,7 @@ const Chat = (props) => {
 
   const handleClick = async (conversation) => {
     await props.setActiveChat(conversation.otherUser.username);
+    await props.resetUnread(conversation);
   };
 
   return (
@@ -45,7 +47,10 @@ const mapDispatchToProps = (dispatch) => {
   return {
     setActiveChat: (id) => {
       dispatch(setActiveChat(id));
-    }
+    },
+    resetUnread: (conversation) => {
+      dispatch(resetUnread(conversation));
+    },
   };
 };
 

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -3,7 +3,7 @@ import { Box } from "@material-ui/core";
 import { BadgeAvatar, ChatContent } from "../Sidebar";
 import { makeStyles } from "@material-ui/core/styles";
 import { setActiveChat } from "../../store/activeConversation";
-import { resetUnread } from "../../store/utils/thunkCreators";
+import { resetUnreadCount } from "../../store/utils/thunkCreators";
 import { connect } from "react-redux";
 
 const useStyles = makeStyles((theme) => ({
@@ -29,7 +29,7 @@ const Chat = (props) => {
     await props.setActiveChat(conversation.otherUser.username);
     const lastMessage = conversation.messages && conversation.messages.slice(-1);
     if (lastMessage[0] && lastMessage[0].senderId !== user.id){
-      await props.resetUnread(conversation);
+      await props.resetUnreadCount(conversation);
     }
   };
 
@@ -51,8 +51,8 @@ const mapDispatchToProps = (dispatch) => {
     setActiveChat: (id) => {
       dispatch(setActiveChat(id));
     },
-    resetUnread: (conversation) => {
-      dispatch(resetUnread(conversation));
+    resetUnreadCount: (conversation) => {
+      dispatch(resetUnreadCount(conversation));
     },
   };
 };

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -5,6 +5,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { setActiveChat } from "../../store/activeConversation";
 import { resetUnreadCount } from "../../store/utils/thunkCreators";
 import { connect } from "react-redux";
+import { messageStatus } from '../../store/helpers'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -25,23 +26,25 @@ const Chat = (props) => {
   const { conversation, user } = props;
   const { otherUser } = conversation;
 
-  const handleClick = async (conversation, user) => {
+  const lastMessageStatus = messageStatus(user, conversation);
+ 
+  const handleClick = async () => {
     await props.setActiveChat(conversation.otherUser.username);
-    const lastMessage = conversation.messages && conversation.messages.slice(-1);
-    if (lastMessage[0] && lastMessage[0].senderId !== user.id){
+    if (lastMessageStatus){
       await props.resetUnreadCount(conversation);
     }
   };
 
   return (
-    <Box onClick={() => handleClick(conversation, user)} className={classes.root}>
+    <Box onClick={() => handleClick()} className={classes.root}>
       <BadgeAvatar
         photoUrl={otherUser.photoUrl}
         username={otherUser.username}
         online={otherUser.online}
         sidebar={true}
       />
-      <ChatContent conversation={conversation} />
+      <ChatContent conversation={conversation} 
+       lastMessageStatus = {lastMessageStatus}/>
     </Box>
   );
 };

--- a/client/src/components/Sidebar/Chat.js
+++ b/client/src/components/Sidebar/Chat.js
@@ -22,16 +22,19 @@ const useStyles = makeStyles((theme) => ({
 
 const Chat = (props) => {
   const classes = useStyles();
-  const { conversation } = props;
+  const { conversation, user } = props;
   const { otherUser } = conversation;
 
-  const handleClick = async (conversation) => {
+  const handleClick = async (conversation, user) => {
     await props.setActiveChat(conversation.otherUser.username);
-    await props.resetUnread(conversation);
+    const lastMessage = conversation.messages && conversation.messages.slice(-1);
+    if (lastMessage[0] && lastMessage[0].senderId !== user.id){
+      await props.resetUnread(conversation);
+    }
   };
 
   return (
-    <Box onClick={() => handleClick(conversation)} className={classes.root}>
+    <Box onClick={() => handleClick(conversation, user)} className={classes.root}>
       <BadgeAvatar
         photoUrl={otherUser.photoUrl}
         username={otherUser.username}

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -28,9 +28,9 @@ const useStyles = makeStyles((theme) => ({
 const ChatContent = (props) => {
   const classes = useStyles();
 
-  const { conversation, activeConversation } = props;
+  const { conversation, activeConversation, lastMessageStatus } = props;
   const { latestMessageText, otherUser, unread } = conversation;
-
+  
   return (
     <Box className={classes.root}>
       <Box>
@@ -41,7 +41,7 @@ const ChatContent = (props) => {
           {latestMessageText}
         </Typography>
       </Box>
-      { unread > 0 && activeConversation !== otherUser.username &&
+      { lastMessageStatus && unread > 0 && activeConversation !== otherUser.username &&
          <Chip className={classes.unreadMessage} label={unread}/>
       }
     </Box>

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Typography, Chip } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import { connect } from "react-redux";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -27,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
 const ChatContent = (props) => {
   const classes = useStyles();
 
-  const { conversation } = props;
+  const { conversation, activeConversation } = props;
   const { latestMessageText, otherUser, unread } = conversation;
 
   return (
@@ -40,11 +41,17 @@ const ChatContent = (props) => {
           {latestMessageText}
         </Typography>
       </Box>
-      { unread > 0 && 
+      { unread > 0 && activeConversation !== otherUser.username &&
          <Chip className={classes.unreadMessage} label={unread}/>
-        }
+      }
     </Box>
   );
 };
 
-export default ChatContent;
+const mapStateToProps = (state) => {
+  return {
+    activeConversation: state.activeConversation,
+  };
+};
+
+export default connect(mapStateToProps, null)(ChatContent);

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Typography } from "@material-ui/core";
+import { Box, Typography, Chip } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
@@ -18,13 +18,17 @@ const useStyles = makeStyles((theme) => ({
     color: "#9CADC8",
     letterSpacing: -0.17,
   },
+  unreadMessage: {
+    backgroundColor: "#3A8DFF",
+    color: "white",
+  }
 }));
 
 const ChatContent = (props) => {
   const classes = useStyles();
 
   const { conversation } = props;
-  const { latestMessageText, otherUser } = conversation;
+  const { latestMessageText, otherUser, unread } = conversation;
 
   return (
     <Box className={classes.root}>
@@ -36,6 +40,9 @@ const ChatContent = (props) => {
           {latestMessageText}
         </Typography>
       </Box>
+      { unread > 0 && 
+         <Chip className={classes.unreadMessage} label={unread}/>
+        }
     </Box>
   );
 };

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -22,7 +22,7 @@ const useStyles = makeStyles(() => ({
 const Sidebar = (props) => {
   const classes = useStyles();
   const conversations = props.conversations || [];
-  const { handleChange, searchTerm } = props;
+  const { handleChange, searchTerm, user } = props;
 
   return (
     <Box className={classes.root}>
@@ -32,7 +32,7 @@ const Sidebar = (props) => {
       {conversations
         .filter((conversation) => conversation.otherUser.username.includes(searchTerm))
         .map((conversation) => {
-          return <Chat conversation={conversation} key={conversation.otherUser.username} />;
+          return <Chat conversation={conversation} key={conversation.otherUser.username} user={user}/>;
         })}
     </Box>
   );
@@ -40,7 +40,8 @@ const Sidebar = (props) => {
 
 const mapStateToProps = (state) => {
   return {
-    conversations: state.conversations
+    conversations: state.conversations,
+    user: state.user
   };
 };
 

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -5,7 +5,9 @@ import {
   removeOfflineUser,
   addOnlineUser,
 } from "./store/conversations";
-
+import {
+  fetchConversations
+} from "./store/utils/thunkCreators";
 const socket = io(window.location.origin);
 
 socket.on("connect", () => {
@@ -19,7 +21,9 @@ socket.on("connect", () => {
     store.dispatch(removeOfflineUser(id));
   });
   socket.on("new-message", (data) => {
-    store.dispatch(setNewMessage(data.message, data.sender));
+    const unread = true;
+    store.dispatch(setNewMessage(data.message, data.sender, unread));
+    fetchConversations();
   });
 });
 

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -21,8 +21,8 @@ socket.on("connect", () => {
     store.dispatch(removeOfflineUser(id));
   });
   socket.on("new-message", (data) => {
-    const unread = true;
-    store.dispatch(setNewMessage(data.message, data.sender, unread));
+    const { activeConversation } = store.getState();
+    store.dispatch(setNewMessage(data.message, data.sender, activeConversation));
     fetchConversations();
   });
 });

--- a/client/src/socket.js
+++ b/client/src/socket.js
@@ -30,7 +30,6 @@ socket.on("connect", () => {
     const conversation = conversations.find(convo => activeConversation === convo.otherUser.username);
     if (conversation) {
       const data = await updateReadStatus(conversation);
-      store.dispatch(updateUnseenCountStatus(conversation.id));
       store.dispatch(resetUnreadMessagesStatus(conversation.id));
       updateUnreadMessagesStatus(data.conversation.id);
     }

--- a/client/src/store/conversations.js
+++ b/client/src/store/conversations.js
@@ -4,7 +4,8 @@ import {
   addSearchedUsersToStore,
   removeOfflineUserFromStore,
   addMessageToStore,
-  resetMessages,
+  resetUnreadMessages,
+  resetUnseenCount
 } from "./utils/reducerFunctions";
 
 // ACTIONS
@@ -17,7 +18,7 @@ const SET_SEARCHED_USERS = "SET_SEARCHED_USERS";
 const CLEAR_SEARCHED_USERS = "CLEAR_SEARCHED_USERS";
 const ADD_CONVERSATION = "ADD_CONVERSATION";
 const RESET_UNREAD_MESSAGES = "RESET_UNREAD_MESSAGES";
-
+const RESET_UNSEEN_COUNT = "RESET_UNSEEN_COUNT";
 // ACTION CREATORS
 
 export const gotConversations = (conversations) => {
@@ -69,9 +70,16 @@ export const addConversation = (recipientId, newMessage) => {
   };
 };
 
-export const resetUnreadMessages = (conversationId) => {
+export const resetUnreadMessagesStatus = (conversationId) => {
   return {
     type: RESET_UNREAD_MESSAGES,
+    conversationId,
+  };
+};
+
+export const updateUnseenCountStatus = (conversationId) => {
+  return {
+    type: RESET_UNSEEN_COUNT,
     conversationId,
   };
 };
@@ -101,10 +109,15 @@ const reducer = (state = [], action) => {
         action.payload.newMessage
       );
     case RESET_UNREAD_MESSAGES:
-      return resetMessages(
+      return resetUnreadMessages(
         state,
         action.conversationId
       );
+    case RESET_UNSEEN_COUNT:
+    return resetUnseenCount(
+      state,
+      action.conversationId
+    );
     default:
       return state;
   }

--- a/client/src/store/conversations.js
+++ b/client/src/store/conversations.js
@@ -27,10 +27,10 @@ export const gotConversations = (conversations) => {
   };
 };
 
-export const setNewMessage = (message, sender, unread) => {
+export const setNewMessage = (message, sender, activeConversation) => {
   return {
     type: SET_MESSAGE,
-    payload: { message, sender: sender || null, unread: unread },
+    payload: { message, sender: sender || null, activeConversation },
   };
 };
 

--- a/client/src/store/conversations.js
+++ b/client/src/store/conversations.js
@@ -4,6 +4,7 @@ import {
   addSearchedUsersToStore,
   removeOfflineUserFromStore,
   addMessageToStore,
+  resetMessages,
 } from "./utils/reducerFunctions";
 
 // ACTIONS
@@ -15,6 +16,7 @@ const REMOVE_OFFLINE_USER = "REMOVE_OFFLINE_USER";
 const SET_SEARCHED_USERS = "SET_SEARCHED_USERS";
 const CLEAR_SEARCHED_USERS = "CLEAR_SEARCHED_USERS";
 const ADD_CONVERSATION = "ADD_CONVERSATION";
+const RESET_UNREAD_MESSAGES = "RESET_UNREAD_MESSAGES";
 
 // ACTION CREATORS
 
@@ -25,10 +27,10 @@ export const gotConversations = (conversations) => {
   };
 };
 
-export const setNewMessage = (message, sender) => {
+export const setNewMessage = (message, sender, unread) => {
   return {
     type: SET_MESSAGE,
-    payload: { message, sender: sender || null },
+    payload: { message, sender: sender || null, unread: unread },
   };
 };
 
@@ -67,6 +69,13 @@ export const addConversation = (recipientId, newMessage) => {
   };
 };
 
+export const resetUnreadMessages = (conversationId) => {
+  return {
+    type: RESET_UNREAD_MESSAGES,
+    conversationId,
+  };
+};
+
 // REDUCER
 
 const reducer = (state = [], action) => {
@@ -90,6 +99,11 @@ const reducer = (state = [], action) => {
         state,
         action.payload.recipientId,
         action.payload.newMessage
+      );
+    case RESET_UNREAD_MESSAGES:
+      return resetMessages(
+        state,
+        action.conversationId
       );
     default:
       return state;

--- a/client/src/store/helpers.js
+++ b/client/src/store/helpers.js
@@ -8,3 +8,12 @@ export const getLastSeenMessage = (user, conversation) => {
   }
   return lastMessage;
 };
+
+export const messageStatus = (user, conversation) => {
+  const lastMessage = conversation.messages && conversation.messages.slice(-1);
+  let lastMessageStatus;
+  if (conversation.id) {
+   lastMessageStatus = lastMessage && lastMessage[0].senderId !== user.id;
+  }
+  return lastMessageStatus;
+}

--- a/client/src/store/helpers.js
+++ b/client/src/store/helpers.js
@@ -1,0 +1,10 @@
+export const getLastSeenMessage = (user, conversation) => {
+  const unreadCount = conversation.lastUnseenCount;
+  let lastMessage;
+  if (unreadCount > 0) {
+    lastMessage = conversation.messages && conversation.messages.slice().reverse().filter(message => user.id === message.senderId).slice(unreadCount);
+  } else {
+    lastMessage = conversation.messages && conversation.messages.filter(message => user.id === message.senderId).slice(-1);
+  }
+  return lastMessage;
+};

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -1,11 +1,12 @@
 export const addMessageToStore = (state, payload) => {
-  const { message, sender } = payload;
+  const { message, sender, unread } = payload;
   // if sender isn't null, that means the message needs to be put in a brand new convo
   if (sender !== null) {
     const newConvo = {
       id: message.conversationId,
       otherUser: sender,
       messages: [message],
+      unread: unread ? 1 : 0
     };
     newConvo.latestMessageText = message.text;
     return [newConvo, ...state];
@@ -16,6 +17,9 @@ export const addMessageToStore = (state, payload) => {
       const convoCopy = { ...convo };
       convoCopy.messages = [...convoCopy.messages, message];
       convoCopy.latestMessageText = message.text;
+      if (unread) {
+        convoCopy.unread = convo.unread + 1;
+      }
       return convoCopy;
     } else {
       return convo;
@@ -74,9 +78,22 @@ export const addNewConvoToStore = (state, recipientId, message) => {
       convoCopy.messages = [...convoCopy.messages, message];
       convoCopy.id = message.conversationId;
       convoCopy.latestMessageText = message.text;
+      convoCopy.unread = convo.unread + 1;
       return convoCopy;
     } else {
       return convo;
     }
   });
 };
+
+export const resetMessages = (state, conversationId) => {
+  return state.map((convo) => { 
+    if (convo.id === conversationId) {
+      const convoCopy = { ...convo };
+      convoCopy.unread = 0;
+      return convoCopy;
+    } else {
+      return convo;
+    }
+  });
+}

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -1,23 +1,31 @@
 export const addMessageToStore = (state, payload) => {
-  const { message, sender } = payload;
+  const { message, sender, activeConversation } = payload;
   // if sender isn't null, that means the message needs to be put in a brand new convo
   if (sender !== null) {
+    const newState = state.filter((convo) => convo.otherUser.id !== sender.id);
     const newConvo = {
       id: message.conversationId,
       otherUser: sender,
       messages: [message],
-      unread: payload.unread ? 1 : 0
+      unread: 1,
+      lastUnseenCount: 1
     };
     newConvo.latestMessageText = message.text;
-    return [newConvo, ...state];
+    return [newConvo, ...newState];
   }
   return state.map((convo) => {
     if (convo.id === message.conversationId) {
       const convoCopy = { ...convo };
       convoCopy.messages = [...convoCopy.messages, message];
       convoCopy.latestMessageText = message.text;
-      if (payload.unread) {
+      if (typeof activeConversation !== "undefined" && activeConversation !== convo.otherUser.username) {
         convoCopy.unread = convo.unread + 1;
+      }
+      if (typeof activeConversation === "undefined") {
+        convoCopy.lastUnseenCount = convo.lastUnseenCount + 1;
+      }
+      if (typeof activeConversation !== "undefined" && activeConversation === convo.otherUser.username) {
+        convoCopy.lastUnseenCount = convo.lastUnseenCount - 1;
       }
       return convoCopy;
     } else {

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -24,9 +24,6 @@ export const addMessageToStore = (state, payload) => {
       if (typeof activeConversation === "undefined") {
         convoCopy.lastUnseenCount = convo.lastUnseenCount + 1;
       }
-      if (typeof activeConversation !== "undefined" && activeConversation === convo.otherUser.username) {
-        convoCopy.lastUnseenCount = convo.lastUnseenCount - 1;
-      }
       return convoCopy;
     } else {
       return convo;
@@ -92,11 +89,23 @@ export const addNewConvoToStore = (state, recipientId, message) => {
   });
 };
 
-export const resetMessages = (state, conversationId) => {
+export const resetUnreadMessages = (state, conversationId) => {
   return state.map((convo) => { 
     if (convo.id === conversationId) {
       const convoCopy = { ...convo };
       convoCopy.unread = 0;
+      return convoCopy;
+    } else {
+      return convo;
+    }
+  });
+}
+
+export const resetUnseenCount = (state, conversationId) => {
+  return state.map((convo) => { 
+    if (convo.id === conversationId) {
+      const convoCopy = { ...convo };
+      convoCopy.lastUnseenCount = 0;
       return convoCopy;
     } else {
       return convo;

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -94,6 +94,7 @@ export const resetUnreadMessages = (state, conversationId) => {
     if (convo.id === conversationId) {
       const convoCopy = { ...convo };
       convoCopy.unread = 0;
+      convoCopy.lastUnseenCount = 0;
       return convoCopy;
     } else {
       return convo;

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -11,7 +11,6 @@ export const addMessageToStore = (state, payload) => {
     newConvo.latestMessageText = message.text;
     return [newConvo, ...state];
   }
-  // convert from mutable to immutable state to add message
   return state.map((convo) => {
     if (convo.id === message.conversationId) {
       const convoCopy = { ...convo };
@@ -70,7 +69,7 @@ export const addSearchedUsersToStore = (state, users) => {
 
   return newState;
 };
-// convert from mutable to immutable state to add new conversation
+
 export const addNewConvoToStore = (state, recipientId, message) => {
   return state.map((convo) => {
     if (convo.otherUser.id === recipientId) {

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -1,12 +1,12 @@
 export const addMessageToStore = (state, payload) => {
-  const { message, sender, unread } = payload;
+  const { message, sender } = payload;
   // if sender isn't null, that means the message needs to be put in a brand new convo
   if (sender !== null) {
     const newConvo = {
       id: message.conversationId,
       otherUser: sender,
       messages: [message],
-      unread: unread ? 1 : 0
+      unread: payload.unread ? 1 : 0
     };
     newConvo.latestMessageText = message.text;
     return [newConvo, ...state];
@@ -17,7 +17,7 @@ export const addMessageToStore = (state, payload) => {
       const convoCopy = { ...convo };
       convoCopy.messages = [...convoCopy.messages, message];
       convoCopy.latestMessageText = message.text;
-      if (unread) {
+      if (payload.unread) {
         convoCopy.unread = convo.unread + 1;
       }
       return convoCopy;
@@ -78,7 +78,6 @@ export const addNewConvoToStore = (state, recipientId, message) => {
       convoCopy.messages = [...convoCopy.messages, message];
       convoCopy.id = message.conversationId;
       convoCopy.latestMessageText = message.text;
-      convoCopy.unread = convo.unread + 1;
       return convoCopy;
     } else {
       return convo;

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -5,7 +5,8 @@ import {
   addConversation,
   setNewMessage,
   setSearchedUsers,
-  resetUnreadMessages
+  resetUnreadMessagesStatus,
+  updateUnseenCountStatus
 } from "../conversations";
 import { gotUser, setFetchingStatus } from "../user";
 
@@ -119,11 +120,22 @@ export const searchUsers = (searchTerm) => async (dispatch) => {
   }
 };
 
-export const resetUnread = (conversation) => async (dispatch) => {
+export const updateReadStatus = async (conversation) => {
+  const { data } = await axios.put("/api/conversations/unread", conversation);
+  return data;
+};
+
+export const resetUnreadCount = (conversation) => async (dispatch) => {
   try {
-    await axios.put("/api/conversations/unread", conversation);
-    dispatch(resetUnreadMessages(conversation.id));
+    const data = await updateReadStatus(conversation);
+    dispatch(updateUnseenCountStatus(conversation.id));
+    dispatch(resetUnreadMessagesStatus(conversation.id));
+    updateUnreadMessagesStatus(data.conversation.id);
   } catch (error) {
     console.error(error);
   }
 };
+
+export const updateUnreadMessagesStatus = (data) => {
+  socket.emit("update-unread-status", data);
+}

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -6,7 +6,6 @@ import {
   setNewMessage,
   setSearchedUsers,
   resetUnreadMessagesStatus,
-  updateUnseenCountStatus
 } from "../conversations";
 import { gotUser, setFetchingStatus } from "../user";
 
@@ -128,7 +127,6 @@ export const updateReadStatus = async (conversation) => {
 export const resetUnreadCount = (conversation) => async (dispatch) => {
   try {
     const data = await updateReadStatus(conversation);
-    dispatch(updateUnseenCountStatus(conversation.id));
     dispatch(resetUnreadMessagesStatus(conversation.id));
     updateUnreadMessagesStatus(data.conversation.id);
   } catch (error) {

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -5,6 +5,7 @@ import {
   addConversation,
   setNewMessage,
   setSearchedUsers,
+  resetUnreadMessages
 } from "../conversations";
 import { gotUser, setFetchingStatus } from "../user";
 
@@ -114,6 +115,15 @@ export const searchUsers = (searchTerm) => async (dispatch) => {
   try {
     const { data } = await axios.get(`/api/users/${searchTerm}`);
     dispatch(setSearchedUsers(data));
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const resetUnread = (conversation) => async (dispatch) => {
+  try {
+    await axios.post("/api/conversations/unread", conversation);
+    dispatch(resetUnreadMessages(conversation.id));
   } catch (error) {
     console.error(error);
   }

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -121,7 +121,7 @@ export const searchUsers = (searchTerm) => async (dispatch) => {
 
 export const resetUnread = (conversation) => async (dispatch) => {
   try {
-    await axios.post("/api/conversations/unread", conversation);
+    await axios.put("/api/conversations/unread", conversation);
     dispatch(resetUnreadMessages(conversation.id));
   } catch (error) {
     console.error(error);

--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -96,7 +96,6 @@ const sendMessage = (data, body) => {
 // conversationId will be set to null if its a brand new conversation
 export const postMessage = (body) => async (dispatch) => {
   try {
-    // add async await as saveMessage() returns promise
     const data = await saveMessage(body);
 
     if (!body.conversationId) {

--- a/server/bin/www
+++ b/server/bin/www
@@ -54,6 +54,10 @@ io.on("connection", (socket) => {
       socket.broadcast.emit("remove-offline-user", id);
     }
   });
+
+  socket.on("update-unread-status", (data) => {
+    socket.broadcast.emit("update-unread-status", data);
+  });
 });
 
 sessionStore

--- a/server/db/models/conversation.js
+++ b/server/db/models/conversation.js
@@ -1,8 +1,15 @@
 const { Op } = require("sequelize");
+const Sequelize = require("sequelize");
 const db = require("../db");
 const Message = require("./message");
 
-const Conversation = db.define("conversation", {});
+const Conversation = db.define("conversation", {
+  unread: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+  },
+});
 
 // find conversation given two user Ids
 

--- a/server/db/models/conversation.js
+++ b/server/db/models/conversation.js
@@ -9,6 +9,11 @@ const Conversation = db.define("conversation", {
     allowNull: false,
     defaultValue: 0,
   },
+  lastUnseenCount: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: 0
+  }
 });
 
 // find conversation given two user Ids

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -1,17 +1,19 @@
 const Conversation = require("./conversation");
 const User = require("./user");
 const Message = require("./message");
+const UserConversation = require('./userConversation');
 
 // associations
 
-User.hasMany(Conversation);
-Conversation.belongsTo(User, { as: "user1" });
-Conversation.belongsTo(User, { as: "user2" });
+User.belongsToMany(Conversation, { through: UserConversation});
+Conversation.belongsToMany(User, { through: UserConversation });
+
 Message.belongsTo(Conversation);
 Conversation.hasMany(Message);
 
 module.exports = {
   User,
   Conversation,
-  Message
+  Message,
+  UserConversation
 };

--- a/server/db/models/userConversation.js
+++ b/server/db/models/userConversation.js
@@ -1,0 +1,13 @@
+const Sequelize = require("sequelize");
+const db = require("../db");
+
+// Junction model of many-to-many relationship between User and Conversation.
+const UserConversation = db.define("user_conversation", {
+  unread: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: 0
+  }
+});
+
+module.exports = UserConversation;

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -86,7 +86,7 @@ router.get("/", async (req, res, next) => {
 router.put("/unread", async (req, res, next) => {
   try {
     const { id } = req.body;
-    const conversation = await Conversation.update({
+    await Conversation.update({
       unread: 0,
       lastUnseenCount: 0
     },{
@@ -94,11 +94,17 @@ router.put("/unread", async (req, res, next) => {
         id: id
       }
     })
+  
+    const conversation = await Conversation.findOne(
+    { 
+      where:{ 
+        id: id
+      }
+    })
+    res.status(200).json({conversation: conversation});
   } catch (error) {
     next(error);
   }
-  
-  res.status(200).json({"message": "Successfully unread messages is reset"});
 });
 
 module.exports = router;

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -18,7 +18,7 @@ router.get("/", async (req, res, next) => {
           user2Id: userId,
         },
       },
-      attributes: ["id"],
+      attributes: ["id", "unread"],
       order: [[Message, "createdAt", "DESC"]],
       include: [
         { model: Message, order: ["createdAt", "ASC"] },
@@ -81,6 +81,22 @@ router.get("/", async (req, res, next) => {
   } catch (error) {
     next(error);
   }
+});
+
+router.post("/unread", async (req, res, next) => {
+  try {
+    const { id } = req.body;
+    await Conversation.update({
+      unread: 0
+    },{
+      where: {
+        id: id
+      }
+    })
+  } catch (error) {
+    next(error);
+  }
+  res.status(200).json({"message": "Successfully unread messages is reset"});
 });
 
 module.exports = router;

--- a/server/routes/api/conversations.js
+++ b/server/routes/api/conversations.js
@@ -18,10 +18,10 @@ router.get("/", async (req, res, next) => {
           user2Id: userId,
         },
       },
-      attributes: ["id", "unread"],
+      attributes: ["id", "unread", "lastUnseenCount"],
       order: [[Message, "createdAt", "DESC"]],
       include: [
-        { model: Message, order: ["createdAt", "ASC"] },
+        { model: Message, order: ["createdAt", "DESC"] },
         {
           model: User,
           as: "user1",
@@ -83,11 +83,12 @@ router.get("/", async (req, res, next) => {
   }
 });
 
-router.post("/unread", async (req, res, next) => {
+router.put("/unread", async (req, res, next) => {
   try {
     const { id } = req.body;
-    await Conversation.update({
-      unread: 0
+    const conversation = await Conversation.update({
+      unread: 0,
+      lastUnseenCount: 0
     },{
       where: {
         id: id
@@ -96,6 +97,7 @@ router.post("/unread", async (req, res, next) => {
   } catch (error) {
     next(error);
   }
+  
   res.status(200).json({"message": "Successfully unread messages is reset"});
 });
 

--- a/server/routes/api/messages.js
+++ b/server/routes/api/messages.js
@@ -14,6 +14,14 @@ router.post("/", async (req, res, next) => {
     // if we already know conversation id, we can save time and just add it to message and return
     if (conversationId) {
       const message = await Message.create({ senderId, text, conversationId });
+      await Conversation.increment({ 
+        unread: 1 
+        }, {
+        where: { 
+          user1Id: senderId,
+          user2Id: recipientId,
+        }
+       })
       return res.json({ message, sender });
     }
     // if we don't have conversation id, find a conversation to make sure it doesn't already exist
@@ -27,6 +35,7 @@ router.post("/", async (req, res, next) => {
       conversation = await Conversation.create({
         user1Id: senderId,
         user2Id: recipientId,
+        unread: 1
       });
       if (onlineUsers.includes(sender.id)) {
         sender.online = true;


### PR DESCRIPTION
[#closes: 4 Draft Database Redesign](https://github.com/meghal-softwaredev/492cb7/issues/4)

## Description

Draft to redesign database and plan to add group chat as a new feature.

## Notes on your approach and thought process

Different ways to implement this feature:

1. Create UserConversation junction model to handle M:N relationships between User and Conversation model.
Advantage:  Easy to store and retrieve information and efficient to handle state of application.

2. Create UserMessage junction model to handle M:N relationships between User and Message model.
Advantage: Simple database model
Disadvantage: Difficult to store and retrieve information as messages is part of conversations as well as extra effort required to deal with state.

As first approach is better and require less database changes, so decided to go with that approach.

Database related changes: 
Create UserConversation junction model to handle many to many relationship between User and Conversation models.

```
UserConversation = sequelize.define('user_conversation', {
unread: {
    type: Sequelize.INTEGER,
    allowNull: false,
    defaultValue: 0
  }
});
User.belongsToMany(Conversation, { through: UserConversation});
Conversation.belongsToMany(User, { through: UserConversation });
```

- Store unread messages in UserConversation junction model, to keep track of which user has how many number of unread messages for that particular conversation.
- UserConversation junction model will have userId and ConversationId forming composite key implicitly.
- Remove unread, lastUnseenCount and association “user1” and “user2” from Conversation model.

1. What additional (non-database) changes are needed to implement this feature?

Changes related to User Experience

- Need to change UI, so that a user can create a group, provide a name, group icon as well as add and remove users from a conversation.
- Once group is created, messages should be sent to all users and need to keep track of unread messages for specific user for particular conversation to show unread message badge in side bar and avatar below last read message.
- Multiple avatars who have seen message to be shown to sender.

Back-end changes (Server-side)

- For particular conversation, store array of users (i.e. otherUser) instead of one user.
- Create an PUT request API endpoint to add/remove users in particular conversation.
- When a user is added or removed, broadcast it to all other users of a conversation.
- In messages.js, modify api/messages/ POST request when new message appears for new or existing conversation, required to increment unread attribute for all users of particular conversation.
- When new-message socket event occurs, broadcast that message to all users of that conversation.
- In conversation.js, modify api/conversations/unread endpoint, when particular user clicks on unread badge in side bar then reset unread count of that user for particular conversation.

Front-end changes (Client-side)

- Implement thunk creator to handle add/remove users in particular conversation, which will call backend api and dispatch function to update store.
- Active conversation will have array of active users.
- Update new-message socket event and check if user is part of that conversation then only dispatch setNewMessage.
- To display number of unread messages for each conversation in side bar, update reducer function addMessageToStore(). Instead of updating unread attribute of conversation model, increment unread attribute of UserConversation model for that user for particular conversation.
- To reset unread badge in side bar, update resetUnreadMessages() to change state of unread messages to 0, for that user for particular conversation.
- In ActiveChat, getLastSeenMessage() status of all other users who have seen message and pass props to SenderBubble to show avatars of other users below send message.

2. If our app were already deployed, what steps would we need to take to move to this new feature without disrupting service for current users?

- In our case version 1 of application is up, so need to take database backup as a precaution.
- Migration of database from old to new version.
- Deploy version 2 of application in parallel to the version 1.
- Once version 2 works fine bring down version 1.

How would you update route handlers to reflect the new M:N relationship between User and Conversation?

Back-end changes (Server-side)

- When conversation is new, create a POST request API endpoint in conversations.js, if want to add many users, otherUsers will be array of all users of that conversation and if 1 other user then otherUsers will be array of two users ( users will be received by taking input from front end in body of POST request) and return a newly created conversation.
- When existing conversation, in messages.js POST request API endpoint when new message arrives find that conversation, create new message and set senderId for that message so we can come to know who is sender.
- If want to remove user from particular conversation, create PUT request API endpoint in conversations.js, find that conversation and remove user from array of otherUsers.

How would you update Redux state to reflect the new M:N relationship between User and Conversation?

Front-end changes (Client-side)

- When create group button is clicked, dispatch method that will lead to thunk creator, it will call POST api to create new conversation and dispatch method to update state using returned data. All the users of group will be passed in body of post request as an array.
- Dispatch method will call action creator in conversations.js and reducer will be called to update state of application to add conversation.
- When conversation is existing, dispatch setNewMessage which will set new message.
- When want to remove user from conversation, we can have exit group button in that conversation when clicked, it will call thunk creator to make an PUT request API call to backend to remove that user and dispatch a method to update state to remove user from that particular conversation.

Migration of database from old to new version?

We can move current users to this new feature without disrupting service by using Blue-green deployment strategy.
- Blue-green is a deployment strategy to test the new version of a service. In this model, both blue and green will be up and running at some point of time and then gracefully migrate from one to the other.
- maintain two copies of production environment (“blue” and “green”).
- route all traffic to the the blue environment by mapping production URLs to it.
- deploy and test any changes to the application in the green environment.
- “flip the switch” by mapping URLs onto green and unmapping them from blue.

Advantage: zero downtime deployment

## Further comments (optional)
- Need to do extensively planning and research before implementing any feature.